### PR TITLE
Fix screenshot on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Screenshot
 
-![Screenshot](http://raw.githubusercontent.com/CJTozer/SublimeDiffView/master/img/screen_1.png)
+![Screenshot](https://raw.githubusercontent.com/CJTozer/SublimeDiffView/master/img/screen_1.png)
 
 ## Usage
 * `Alt + Shift + D` to run a diff

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Screenshot
 
-![Screenshot](https://raw.githubusercontent.com/CJTozer/SublimeDiffView/master/img/screen_1.png)
+![Screenshot](https://raw.githubusercontent.com/CJTozer/SublimeDiffView/master/img/screen_1.png "Screenshot from Git diff")
 
 ## Usage
 * `Alt + Shift + D` to run a diff

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Screenshot
 
-![Screenshot](http://raw.githubusercontent.com/CJTozer/SublimeDiffView/master/img/screen_1.png "Screenshot from Git diff")
+![Screenshot](http://raw.githubusercontent.com/CJTozer/SublimeDiffView/master/img/screen_1.png)
 
 ## Usage
 * `Alt + Shift + D` to run a diff


### PR DESCRIPTION
Needs to work on [packagecontrol.io](https://packagecontrol.io/packages/DiffView) too, which doesn't like the GitHub-preferred relative links.