### PR TITLE
SVN detection failed on folders with spaces

### DIFF
--- a/util/vcs.py
+++ b/util/vcs.py
@@ -13,7 +13,7 @@ class VCSHelper(object):
     directory.
     """
     __metaclass__ = ABCMeta
-    SVN_BASE_MATCH = re.compile('Root Path:\s*([\:\\\\/\w\.\-]*)')
+    SVN_BASE_MATCH = re.compile('Root Path:\s*([\:\\\\/\w\.\- ]*)')
 
     @classmethod
     def get_helper(cls, cwd):


### PR DESCRIPTION
The SVN regex matching the filename in the repo folder detection function would not return the full path if it contained spaces.