### PR TITLE
Added error parameter 'replace' for UTF-8 string decode

### DIFF
--- a/util/vcs.py
+++ b/util/vcs.py
@@ -141,7 +141,7 @@ class VCSHelper(object):
             print("** VCS command returns output:\n%s" % out)
             if err:
                 print("** VCS command returns error:\n%s" % err)
-        return out.decode('utf-8')
+        return out.decode('utf-8', 'replace')
 
 
 class NoVCSError(Exception):


### PR DESCRIPTION
I required this change locally due to Unicode decode errors for a repository containing some non-Unicode characters riddled throughout.

I have ensured that this change passes the unit tests present on the develop branch as per the contributing guidelines.  I hope this is helpful and an acceptable error parameter for string decodes; thanks for the awesome plugin!